### PR TITLE
fix(CI): Run CI jobs on update types PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,11 @@ on:
       - master
     tags:
       - '*'
+  workflow_run:
+    workflows:
+      - "Update Types"
+    types:
+      - completed
 
 jobs:
   lint:

--- a/.github/workflows/generate-types.yaml
+++ b/.github/workflows/generate-types.yaml
@@ -41,7 +41,7 @@ jobs:
           if git diff --cached --quiet; then
             echo "No changes to commit"
           else
-            git commit -m 'Update vadnu-sync Lua types'
+          git commit -m 'chore(bot): Update vadnu-sync Lua types'
           fi
 
       - name: Create Pull Request


### PR DESCRIPTION
By default workflows don't trigger workflows, including workflows that
create Pull Requests.  Apparently you can opt-in to a workflow
triggering on another one by configuring a `workflow_run` trigger.
